### PR TITLE
[PR] #4 - Refactor error handler to use logger.error instead of console.error and fix related tests

### DIFF
--- a/products-service/src/middlewares/errorHandler.js
+++ b/products-service/src/middlewares/errorHandler.js
@@ -1,5 +1,14 @@
+const logger = require('../utils/logger');
+
 const errorHandler = (err, req, res, next) => {
-  console.error('[ERROR]', err.message);
+  logger.error({
+    msg: 'Unhandled error',
+    method: req.method,
+    url: req.originalUrl,
+    status: err.status || 500,
+    error: err.message,
+    stack: err.stack
+  });
 
   const status = err.status || 500;
 

--- a/products-service/src/server.js
+++ b/products-service/src/server.js
@@ -1,10 +1,11 @@
 const app = require('./app');
+const logger = require('./utils/logger');
 const sequelize = require('./database');
 require('./models/product.model');
 
 const PORT = process.env.PORT || 3000;
 
 sequelize.sync().then(() => {
-  console.log('Database synced');
+  logger.info('Database synced');
   app.listen(PORT, () => console.log(`Products service running on port ${PORT}`));
 });

--- a/products-service/src/services/product.service.js
+++ b/products-service/src/services/product.service.js
@@ -21,6 +21,7 @@ async function findById(id) {
       logger.warn({ id }, 'Product not found');
       throw error;
     }
+    logger.info({ id, product: product }, 'Product updated');
     return product;
   } catch (err) {
     if (!err.status) {

--- a/products-service/tests/middlewares/errorHandler.test.js
+++ b/products-service/tests/middlewares/errorHandler.test.js
@@ -1,20 +1,22 @@
 const errorHandler = require('../../src/middlewares/errorHandler');
+const logger = require('../../src/utils/logger');
+
+jest.mock('../../src/utils/logger');
 
 describe('errorHandler middleware', () => {
   let req, res, next;
 
   beforeEach(() => {
-    req = {};
+    req = {
+      method: 'GET',
+      originalUrl: '/test-route',
+    };
     res = {
       status: jest.fn().mockReturnThis(),
       json: jest.fn(),
     };
     next = jest.fn();
-    jest.spyOn(console, 'error').mockImplementation(() => {});
-  });
-
-  afterEach(() => {
-    jest.restoreAllMocks();
+    jest.clearAllMocks();
   });
 
   test('should handle errors with status and message', () => {
@@ -22,7 +24,14 @@ describe('errorHandler middleware', () => {
 
     errorHandler(err, req, res, next);
 
-    expect(console.error).toHaveBeenCalledWith('[ERROR]', 'Not Found');
+    expect(logger.error).toHaveBeenCalledWith(expect.objectContaining({
+      msg: 'Unhandled error',
+      method: 'GET',
+      url: '/test-route',
+      status: 404,
+      error: 'Not Found',
+    }));
+
     expect(res.status).toHaveBeenCalledWith(404);
     expect(res.json).toHaveBeenCalledWith({
       errors: [{ status: 404, detail: 'Not Found' }],
@@ -34,7 +43,14 @@ describe('errorHandler middleware', () => {
 
     errorHandler(err, req, res, next);
 
-    expect(console.error).toHaveBeenCalledWith('[ERROR]', undefined);
+    expect(logger.error).toHaveBeenCalledWith(expect.objectContaining({
+      msg: 'Unhandled error',
+      method: 'GET',
+      url: '/test-route',
+      status: 500,
+      error: undefined,
+    }));
+
     expect(res.status).toHaveBeenCalledWith(500);
     expect(res.json).toHaveBeenCalledWith({
       errors: [{ status: 500, detail: 'Internal Server Error' }],


### PR DESCRIPTION
Este PR realiza un refactor en el middleware de manejo de errores (`errorHandler`) para eliminar el uso de `console.error` y utilizar en su lugar `logger.error`, asegurando un logging centralizado y consistente.

Además, se actualizan los tests correspondientes para reflejar este cambio, mockeando `logger.error` en lugar de `console.error`.

Cambios incluidos:
- Reemplazo de `console.error` por `logger.error` en `errorHandler.js`
- Refactor y corrección de los tests en `errorHandler.test.js` para que pasen correctamente
- Uso de `jest.mock()` para interceptar llamadas a `logger.error`

Este cambio ayuda a mantener mejores prácticas de logging y evita duplicidad en la salida de errores en consola.
