### PR TITLE
[PR] #5 - Add API Key authentication to products-service

### DIFF
--- a/inventory-service/package-lock.json
+++ b/inventory-service/package-lock.json
@@ -10,6 +10,7 @@
       "license": "ISC",
       "dependencies": {
         "axios": "^1.10.0",
+        "dotenv": "^17.0.0",
         "express": "^5.1.0",
         "pino": "^9.7.0",
         "pino-pretty": "^13.0.0",
@@ -2448,6 +2449,17 @@
       "dependencies": {
         "asap": "^2.0.0",
         "wrappy": "1"
+      }
+    },
+    "node_modules/dotenv": {
+      "version": "17.0.0",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-17.0.0.tgz",
+      "integrity": "sha512-A0BJ5lrpJVSfnMMXjmeO0xUnoxqsBHWCoqqTnGwGYVdnctqXXUEhJOO7LxmgxJon9tEZFGpe0xPRX0h2v3AANQ==",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://dotenvx.com"
       }
     },
     "node_modules/dottie": {

--- a/inventory-service/package.json
+++ b/inventory-service/package.json
@@ -15,6 +15,7 @@
   "description": "",
   "dependencies": {
     "axios": "^1.10.0",
+    "dotenv": "^17.0.0",
     "express": "^5.1.0",
     "pino": "^9.7.0",
     "pino-pretty": "^13.0.0",

--- a/inventory-service/src/app.js
+++ b/inventory-service/src/app.js
@@ -1,12 +1,14 @@
+require('dotenv').config();
 const express = require('express');
 const inventoryRoutes = require('./routes/inventory.routes');
 const healthRoutes = require('./routes/health.routes');
 const errorHandler = require('./middlewares/errorHandler');
+const auth = require('./middlewares/auth');
 
 const app = express();
 app.use(express.json());
 
-app.use('/inventory', inventoryRoutes);
+app.use('/inventory', auth, inventoryRoutes);
 app.use('/health', healthRoutes);
 
 app.use((req, res, next) => {

--- a/inventory-service/src/middlewares/auth.js
+++ b/inventory-service/src/middlewares/auth.js
@@ -1,0 +1,26 @@
+const logger = require('../utils/logger');
+
+module.exports = function apiKeyAuth(req, res, next) {
+  const apiKey = req.headers['x-api-key'];
+
+  if (!apiKey || apiKey !== process.env.INTERNAL_API_KEY) {
+    logger.warn({
+      msg: 'Unauthorized access attempt',
+      method: req.method,
+      url: req.originalUrl,
+      providedApiKey: apiKey
+    });
+
+    return res.status(401).json({
+      errors: [{ status: 401, detail: 'Unauthorized: Invalid API Key' }]
+    });
+  }
+
+  logger.info({
+    msg: 'Authorized internal request',
+    method: req.method,
+    url: req.originalUrl
+  });
+
+  next();
+};

--- a/inventory-service/src/services/inventory.service.js
+++ b/inventory-service/src/services/inventory.service.js
@@ -4,7 +4,11 @@ const axios = require('axios');
 
 async function getProductDetails(productId) {
   try {
-    const res = await axios.get(`http://localhost:3000/products/${productId}`);
+    const res = await axios.get(`http://localhost:3000/products/${productId}`, {
+      headers: {
+        'x-api-key': process.env.PRODUCTS_SERVICE_API_KEY
+      }
+    });
     return res.data.data.attributes;
   } catch (err) {
     throw new Error('Product not found in product service');

--- a/products-service/package-lock.json
+++ b/products-service/package-lock.json
@@ -9,6 +9,7 @@
       "version": "1.0.0",
       "license": "ISC",
       "dependencies": {
+        "dotenv": "^17.0.0",
         "express": "^5.1.0",
         "pino": "^9.7.0",
         "pino-pretty": "^13.0.0",
@@ -2463,6 +2464,17 @@
       "dependencies": {
         "asap": "^2.0.0",
         "wrappy": "1"
+      }
+    },
+    "node_modules/dotenv": {
+      "version": "17.0.0",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-17.0.0.tgz",
+      "integrity": "sha512-A0BJ5lrpJVSfnMMXjmeO0xUnoxqsBHWCoqqTnGwGYVdnctqXXUEhJOO7LxmgxJon9tEZFGpe0xPRX0h2v3AANQ==",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://dotenvx.com"
       }
     },
     "node_modules/dottie": {

--- a/products-service/package.json
+++ b/products-service/package.json
@@ -14,6 +14,7 @@
   "license": "ISC",
   "description": "",
   "dependencies": {
+    "dotenv": "^17.0.0",
     "express": "^5.1.0",
     "pino": "^9.7.0",
     "pino-pretty": "^13.0.0",

--- a/products-service/src/app.js
+++ b/products-service/src/app.js
@@ -1,11 +1,14 @@
+require('dotenv').config();
 const express = require('express');
 const productRoutes = require('./routes/product.routes');
 const healthRoutes = require('./routes/health.routes');
 const errorHandler = require('./middlewares/errorHandler');
+const auth = require('./middlewares/auth');
 
 const app = express();
 app.use(express.json());
-app.use('/products', productRoutes);
+
+app.use('/products', auth, productRoutes);
 app.use('/health', healthRoutes);
 
 app.use((req, res, next) => {

--- a/products-service/src/middlewares/auth.js
+++ b/products-service/src/middlewares/auth.js
@@ -1,0 +1,26 @@
+const logger = require('../utils/logger');
+
+module.exports = function apiKeyAuth(req, res, next) {
+  const apiKey = req.headers['x-api-key'];
+
+  if (!apiKey || apiKey !== process.env.INTERNAL_API_KEY) {
+    logger.warn({
+      msg: 'Unauthorized access attempt',
+      method: req.method,
+      url: req.originalUrl,
+      providedApiKey: apiKey
+    });
+
+    return res.status(401).json({
+      errors: [{ status: 401, detail: 'Unauthorized: Invalid API Key' }]
+    });
+  }
+
+  logger.info({
+    msg: 'Authorized internal request',
+    method: req.method,
+    url: req.originalUrl
+  });
+
+  next();
+};


### PR DESCRIPTION
### Cambios realizados
- Se implementó un middleware de autenticación por API Key.
- Se valida la cabecera `x-api-key` contra la variable de entorno `INTERNAL_API_KEY`.
- Se agregó un log de error cuando la clave es inválida o no se proporciona.

### Objetivo
Proteger las rutas del servicio de productos para que solo puedan ser accedidas por servicios internos autorizados.

### Notas adicionales
- Asegúrate de definir `INTERNAL_API_KEY` en tu archivo `.env`.
- Los servicios que consuman este endpoint deberán incluir esta cabecera en sus peticiones.
