### PR TITLE
[PR] #6 - Fix: Remove duplicated ID from inventory API response

### DIFF
--- a/inventory-service/src/services/inventory.service.js
+++ b/inventory-service/src/services/inventory.service.js
@@ -23,13 +23,22 @@ async function getInventoryByProductId(productId) {
       error.status = 404;
       throw error;
     }
+
+    const productData = await getProductDetails(productId);
+    delete productData.id;
     logger.info({ msg: 'Inventory fetched', productId });
-    return inventory;
+
+    return {
+      productId: inventory.productId,
+      quantity: inventory.quantity,
+      ...productData,
+    };
   } catch (err) {
     logger.error({ msg: 'Error retrieving inventory', error: err.message });
     throw err;
   }
 }
+
 
 async function updateInventory(productId, quantity) {
   try {


### PR DESCRIPTION
Este hotfix corrige un error en el endpoint `GET /inventory/:productId` donde la respuesta incluía dos campos "id" dentro del objeto "`attributes`": uno correspondiente al producto (`productId`) y otro proveniente del microservicio de productos (id).  

Se elimina el campo redundante, dejando solo "`productId`" como identificador, y se mantiene el resto de los atributos provenientes del servicio de productos. Esto asegura una respuesta más clara y consistente con el formato JSON:API.
