### PR TITLE
[PR] #11 - Fix: Add error coverage for /health endpoint

### DIFF
--- a/inventory-service/tests/__reports__/test-report.html
+++ b/inventory-service/tests/__reports__/test-report.html
@@ -1,0 +1,277 @@
+<html><head><meta charset="utf-8"/><title>Test Report</title><style type="text/css">:root {
+  --text-primary: #111;
+  --text-secondary: #4f4f4f;
+  --success: #006633;
+  --success-bright: #80ffbf;
+  --danger: #cc071e;
+  --danger-bright: #fbdfe0;
+  --warning: #995c00;
+  --warning-bright: #ffeea8;
+  --panel: #eee;
+  --border: #949494;
+  --disabled: #6b6b6b;
+}
+
+html,
+body {
+  font-family: Arial, Helvetica, sans-serif;
+  font-size: 16px;
+  margin: 0;
+  padding: 0;
+  color: var(--text-primary);
+}
+body {
+  padding: 2rem 1rem;
+}
+.jesthtml-content {
+  margin: 0 auto;
+  max-width: 70rem;
+}
+header {
+  display: flex;
+  align-items: center;
+}
+#title {
+  margin: 0;
+  flex-grow: 1;
+}
+#logo {
+  height: 4rem;
+}
+#timestamp {
+  color: var(--text-secondary);
+  margin-top: 0.5rem;
+}
+
+#metadata-container {
+  display: flex;
+  flex-direction: column;
+  gap: 2rem;
+  margin-bottom: 2rem;
+}
+
+.additional-information-container {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+  color: var(--text-secondary);
+}
+
+/** SUMMARY */
+#summary {
+  color: var(--text-primary);
+  display: flex;
+  font-family: monospace;
+  font-size: 1rem;
+}
+#summary > div {
+  margin-right: 0.5rem;
+  background: var(--panel);
+  padding: 1rem;
+  min-width: 15rem;
+}
+#summary > div:last-child {
+  margin-right: 0;
+}
+@media only screen and (max-width: 720px) {
+  #summary {
+    flex-direction: column;
+  }
+  #summary > div {
+    margin-right: 0;
+    margin-top: 1rem;
+  }
+  #summary > div:first-child {
+    margin-top: 0;
+  }
+}
+
+.summary-total {
+  font-weight: bold;
+  margin-bottom: 0.5rem;
+}
+.summary-passed {
+  color: var(--success);
+  border-left: 0.4rem solid var(--success);
+  padding-left: 0.5rem;
+  margin-bottom: 0.15rem;
+}
+.summary-failed,
+.summary-obsolete-snapshots {
+  color: var(--danger);
+  border-left: 0.4rem solid var(--danger);
+  padding-left: 0.5rem;
+  margin-bottom: 0.15rem;
+}
+.summary-pending {
+  color: var(--warning);
+  border-left: 0.4rem solid var(--warning);
+  padding-left: 0.5rem;
+  margin-bottom: 0.15rem;
+}
+.summary-empty {
+  color: var(--disabled);
+  border-left: 0.4rem solid var(--disabled);
+  margin-bottom: 0.15rem;
+}
+
+.test-result {
+  padding: 1rem;
+  margin-bottom: 0.25rem;
+}
+.test-result:last-child {
+  border: 0;
+}
+.test-result.passed {
+  background-color: var(--success-bright);
+  color: var(--success);
+}
+.test-result.failed {
+  background-color: var(--danger-bright);
+  color: var(--danger);
+}
+.test-result.pending {
+  background-color: var(--warning-bright);
+  color: var(--warning);
+}
+
+.test-info {
+  display: flex;
+  justify-content: space-between;
+}
+.test-suitename {
+  width: 20%;
+  text-align: left;
+  font-weight: bold;
+  word-break: break-word;
+}
+.test-title {
+  width: 40%;
+  text-align: left;
+  font-style: italic;
+}
+.test-status {
+  width: 20%;
+  text-align: right;
+}
+.test-duration {
+  width: 10%;
+  text-align: right;
+  font-size: 0.85rem;
+}
+
+.failureMessages {
+  padding: 0 1rem;
+  margin-top: 1rem;
+  border-top: 1px dashed var(--danger);
+}
+.failureMessages.suiteFailure {
+  border-top: none;
+}
+.failureMsg {
+  white-space: pre-wrap;
+  white-space: -moz-pre-wrap;
+  white-space: -pre-wrap;
+  white-space: -o-pre-wrap;
+  word-wrap: break-word;
+}
+
+.suite-container {
+  margin-bottom: 1rem;
+}
+.suite-info {
+  padding: 1rem;
+  background-color: var(--panel);
+  color: var(--text-secondary);
+  border: 0.15rem solid;
+  border-color: var(--panel);
+  display: flex;
+  align-items: center;
+  margin-bottom: 0.25rem;
+}
+.suite-info:hover {
+  border-color: var(--border);
+  cursor: pointer;
+}
+.suite-info .suite-path {
+  word-break: break-all;
+  flex-grow: 1;
+  font-family: monospace;
+  font-size: 1rem;
+}
+.suite-info .suite-time {
+  margin-left: 1rem;
+  padding: 0.2rem 0.3rem;
+  font-size: 0.85rem;
+}
+.suite-info .suite-time.warn {
+  background-color: var(--danger);
+  color: #fff;
+}
+.suite-info:before {
+  content: "\2303";
+  display: inline-block;
+  margin-right: 1rem;
+  transform: rotate(180deg) translateY(0.15rem);
+}
+.suite-container[open] .suite-info:before {
+  transform: rotate(0deg) translateY(0.15rem);
+}
+
+/* CONSOLE LOGS */
+.suite-consolelog {
+  margin-bottom: 0.25rem;
+  padding: 1rem;
+  background-color: var(--panel);
+}
+.suite-consolelog-header {
+  font-weight: bold;
+}
+.suite-consolelog-item {
+  padding: 0.5rem;
+}
+.suite-consolelog-item pre {
+  margin: 0.5rem 0;
+  white-space: pre-wrap;
+  white-space: -moz-pre-wrap;
+  white-space: -pre-wrap;
+  white-space: -o-pre-wrap;
+  word-wrap: break-word;
+}
+.suite-consolelog-item-origin {
+  color: var(--text-secondary);
+  font-weight: bold;
+}
+.suite-consolelog-item-message {
+  color: var(--text-primary);
+  font-size: 1rem;
+  padding: 0 0.5rem;
+}
+
+/* OBSOLETE SNAPSHOTS */
+.suite-obsolete-snapshots {
+  margin-bottom: 0.25rem;
+  padding: 1rem;
+  background-color: var(--danger-bright);
+  color: var(--danger);
+}
+.suite-obsolete-snapshots-header {
+  font-weight: bold;
+}
+.suite-obsolete-snapshots-item {
+  padding: 0.5rem;
+}
+.suite-obsolete-snapshots-item pre {
+  margin: 0.5rem 0;
+  white-space: pre-wrap;
+  white-space: -moz-pre-wrap;
+  white-space: -pre-wrap;
+  white-space: -o-pre-wrap;
+  word-wrap: break-word;
+}
+.suite-obsolete-snapshots-item-message {
+  color: var(--text-primary);
+  font-size: 1rem;
+  padding: 0 0.5rem;
+}
+</style></head><body><main class="jesthtml-content"><header><h1 id="title">Test Report</h1></header><section id="metadata-container"><div id="timestamp">Started: 2025-07-01 07:48:57</div><div id="summary"><div id="suite-summary"><div class="summary-total">Suites (7)</div><div class="summary-passed ">7 passed</div><div class="summary-failed  summary-empty">0 failed</div><div class="summary-pending  summary-empty">0 pending</div></div><div id="test-summary"><div class="summary-total">Tests (24)</div><div class="summary-passed ">24 passed</div><div class="summary-failed  summary-empty">0 failed</div><div class="summary-pending  summary-empty">0 pending</div></div></div></section><details id="suite-1" class="suite-container" open=""><summary class="suite-info"><div class="suite-path">C:\Users\MSI1\Desktop\camilo_yaya_prueba_linktic\inventory-service\tests\utils\jsonapi.test.js</div><div class="suite-time">0.69s</div></summary><div class="suite-tests"><div class="test-result passed"><div class="test-info"><div class="test-suitename">formatJsonApi</div><div class="test-title">should format a single object correctly</div><div class="test-status">passed</div><div class="test-duration">0.012s</div></div></div><div class="test-result passed"><div class="test-info"><div class="test-suitename">formatJsonApi</div><div class="test-title">should format an array of objects correctly</div><div class="test-status">passed</div><div class="test-duration">0.001s</div></div></div></div></details><details id="suite-2" class="suite-container" open=""><summary class="suite-info"><div class="suite-path">C:\Users\MSI1\Desktop\camilo_yaya_prueba_linktic\inventory-service\tests\middlewares\auth.test.js</div><div class="suite-time">0.691s</div></summary><div class="suite-tests"><div class="test-result passed"><div class="test-info"><div class="test-suitename">auth middleware</div><div class="test-title">should call next() if API key is valid</div><div class="test-status">passed</div><div class="test-duration">0.014s</div></div></div><div class="test-result passed"><div class="test-info"><div class="test-suitename">auth middleware</div><div class="test-title">should respond with 401 if API key is missing</div><div class="test-status">passed</div><div class="test-duration">0.002s</div></div></div><div class="test-result passed"><div class="test-info"><div class="test-suitename">auth middleware</div><div class="test-title">should respond with 401 if API key is invalid</div><div class="test-status">passed</div><div class="test-duration">0.004s</div></div></div></div></details><details id="suite-3" class="suite-container" open=""><summary class="suite-info"><div class="suite-path">C:\Users\MSI1\Desktop\camilo_yaya_prueba_linktic\inventory-service\tests\middlewares\errorHandler.test.js</div><div class="suite-time">0.775s</div></summary><div class="suite-tests"><div class="test-result passed"><div class="test-info"><div class="test-suitename">errorHandler middleware</div><div class="test-title">should handle errors with status and message</div><div class="test-status">passed</div><div class="test-duration">0.028s</div></div></div><div class="test-result passed"><div class="test-info"><div class="test-suitename">errorHandler middleware</div><div class="test-title">should handle errors without status or message</div><div class="test-status">passed</div><div class="test-duration">0.002s</div></div></div></div></details><details id="suite-4" class="suite-container" open=""><summary class="suite-info"><div class="suite-path">C:\Users\MSI1\Desktop\camilo_yaya_prueba_linktic\inventory-service\tests\controllers\inventory.controller.test.js</div><div class="suite-time">1.291s</div></summary><div class="suite-tests"><div class="test-result passed"><div class="test-info"><div class="test-suitename">Inventory Controller &gt; getInventory</div><div class="test-title">should return inventory for valid productId</div><div class="test-status">passed</div><div class="test-duration">0.013s</div></div></div><div class="test-result passed"><div class="test-info"><div class="test-suitename">Inventory Controller &gt; getInventory</div><div class="test-title">should handle invalid productId</div><div class="test-status">passed</div><div class="test-duration">0.003s</div></div></div><div class="test-result passed"><div class="test-info"><div class="test-suitename">Inventory Controller &gt; getInventory</div><div class="test-title">should handle service error</div><div class="test-status">passed</div><div class="test-duration">0.002s</div></div></div><div class="test-result passed"><div class="test-info"><div class="test-suitename">Inventory Controller &gt; updateInventory</div><div class="test-title">should update inventory for valid productId and quantity</div><div class="test-status">passed</div><div class="test-duration">0.002s</div></div></div><div class="test-result passed"><div class="test-info"><div class="test-suitename">Inventory Controller &gt; updateInventory</div><div class="test-title">should handle invalid productId or quantity</div><div class="test-status">passed</div><div class="test-duration">0.002s</div></div></div><div class="test-result passed"><div class="test-info"><div class="test-suitename">Inventory Controller &gt; updateInventory</div><div class="test-title">should handle service error</div><div class="test-status">passed</div><div class="test-duration">0.001s</div></div></div></div></details><details id="suite-5" class="suite-container" open=""><summary class="suite-info"><div class="suite-path">C:\Users\MSI1\Desktop\camilo_yaya_prueba_linktic\inventory-service\tests\services\inventory.service.test.js</div><div class="suite-time">1.288s</div></summary><div class="suite-tests"><div class="test-result passed"><div class="test-info"><div class="test-suitename">inventory.service &gt; getInventoryByProductId</div><div class="test-title">should return combined inventory and product data</div><div class="test-status">passed</div><div class="test-duration">0.009s</div></div></div><div class="test-result passed"><div class="test-info"><div class="test-suitename">inventory.service &gt; getInventoryByProductId</div><div class="test-title">should throw 404 if inventory not found</div><div class="test-status">passed</div><div class="test-duration">0.019s</div></div></div><div class="test-result passed"><div class="test-info"><div class="test-suitename">inventory.service &gt; getInventoryByProductId</div><div class="test-title">should log and throw on DB error</div><div class="test-status">passed</div><div class="test-duration">0.006s</div></div></div><div class="test-result passed"><div class="test-info"><div class="test-suitename">inventory.service &gt; updateInventory</div><div class="test-title">should create new inventory if not exists</div><div class="test-status">passed</div><div class="test-duration">0.013s</div></div></div><div class="test-result passed"><div class="test-info"><div class="test-suitename">inventory.service &gt; updateInventory</div><div class="test-title">should update existing inventory</div><div class="test-status">passed</div><div class="test-duration">0.002s</div></div></div><div class="test-result passed"><div class="test-info"><div class="test-suitename">inventory.service &gt; updateInventory</div><div class="test-title">should throw if product does not exist in product service</div><div class="test-status">passed</div><div class="test-duration">0.001s</div></div></div></div></details><details id="suite-6" class="suite-container" open=""><summary class="suite-info"><div class="suite-path">C:\Users\MSI1\Desktop\camilo_yaya_prueba_linktic\inventory-service\tests\routes\health.test.js</div><div class="suite-time">1.666s</div></summary><div class="suite-tests"><div class="test-result passed"><div class="test-info"><div class="test-suitename">Health Check</div><div class="test-title">should return status ok and log the health check</div><div class="test-status">passed</div><div class="test-duration">0.043s</div></div></div><div class="test-result passed"><div class="test-info"><div class="test-suitename">Health Check</div><div class="test-title">should return 500 when DB connection fails</div><div class="test-status">passed</div><div class="test-duration">0.007s</div></div></div></div></details><details id="suite-7" class="suite-container" open=""><summary class="suite-info"><div class="suite-path">C:\Users\MSI1\Desktop\camilo_yaya_prueba_linktic\inventory-service\tests\app.test.js</div><div class="suite-time">1.782s</div></summary><div class="suite-tests"><div class="test-result passed"><div class="test-info"><div class="test-suitename">App Integration</div><div class="test-title">should respond to /inventory/unknown with 400 for invalid productId</div><div class="test-status">passed</div><div class="test-duration">0.053s</div></div></div><div class="test-result passed"><div class="test-info"><div class="test-suitename">App Integration</div><div class="test-title">should respond to /health with status ok</div><div class="test-status">passed</div><div class="test-duration">0.024s</div></div></div><div class="test-result passed"><div class="test-info"><div class="test-suitename">App Integration</div><div class="test-title">should return 404 for unknown route</div><div class="test-status">passed</div><div class="test-duration">0.006s</div></div></div></div></details></main></body></html>

--- a/inventory-service/tests/app.test.js
+++ b/inventory-service/tests/app.test.js
@@ -22,8 +22,16 @@ describe('App Integration', () => {
   test('should respond to /health with status ok', async () => {
     const res = await request(app).get('/health');
     expect(res.status).toBe(200);
-    expect(res.body).toEqual({ status: 'ok' });
-    expect(logger.info).toHaveBeenCalledWith({ msg: 'Health check passed', status: 'ok' });
+    expect(res.body).toEqual({
+      status: 'ok',
+      database: 'up'
+    });
+    expect(logger.info).toHaveBeenCalledWith({
+      msg: 'Health check passed',
+      status: 'ok',
+      database: 'up'
+    });
+
   });
 
   test('should return 404 for unknown route', async () => {

--- a/products-service/tests/app.test.js
+++ b/products-service/tests/app.test.js
@@ -18,7 +18,10 @@ describe('App Integration', () => {
   });
 
   test('should respond to /products (even if empty)', async () => {
-    const res = await request(app).get('/products');
+    const res = await request(app)
+      .get('/products')
+      .set('x-api-key', process.env.INTERNAL_API_KEY);
+
     expect([200, 500]).toContain(res.statusCode);
   });
 });

--- a/products-service/tests/middlewares/auth.test.js
+++ b/products-service/tests/middlewares/auth.test.js
@@ -1,0 +1,76 @@
+const authMiddleware = require('../../src/middlewares/auth');
+const logger = require('../../src/utils/logger');
+
+jest.mock('../../src/utils/logger', () => ({
+  info: jest.fn(),
+  warn: jest.fn(),
+}));
+
+describe('auth middleware', () => {
+  const next = jest.fn();
+  let req, res;
+
+  beforeEach(() => {
+    process.env.INTERNAL_API_KEY = 'valid-key';
+    req = {
+      headers: {},
+      method: 'GET',
+      originalUrl: '/test',
+    };
+    res = {
+      status: jest.fn().mockReturnThis(),
+      json: jest.fn(),
+    };
+    next.mockClear();
+    logger.info.mockClear();
+    logger.warn.mockClear();
+  });
+
+  test('should call next() if API key is valid', () => {
+    req.headers['x-api-key'] = 'valid-key';
+
+    authMiddleware(req, res, next);
+
+    expect(logger.info).toHaveBeenCalledWith({
+      msg: 'Authorized internal request',
+      method: 'GET',
+      url: '/test',
+    });
+    expect(next).toHaveBeenCalled();
+    expect(res.status).not.toHaveBeenCalled();
+  });
+
+  test('should respond with 401 if API key is missing', () => {
+    authMiddleware(req, res, next);
+
+    expect(logger.warn).toHaveBeenCalledWith(expect.objectContaining({
+      msg: 'Unauthorized access attempt',
+      method: 'GET',
+      url: '/test',
+      providedApiKey: undefined,
+    }));
+    expect(res.status).toHaveBeenCalledWith(401);
+    expect(res.json).toHaveBeenCalledWith({
+      errors: [{ status: 401, detail: 'Unauthorized: Invalid API Key' }],
+    });
+    expect(next).not.toHaveBeenCalled();
+  });
+
+  test('should respond with 401 if API key is invalid', () => {
+    req.headers['x-api-key'] = 'wrong-key';
+
+    authMiddleware(req, res, next);
+
+    expect(logger.warn).toHaveBeenCalledWith(expect.objectContaining({
+      msg: 'Unauthorized access attempt',
+      method: 'GET',
+      url: '/test',
+      providedApiKey: 'wrong-key',
+    }));
+    expect(res.status).toHaveBeenCalledWith(401);
+    expect(res.json).toHaveBeenCalledWith({
+      errors: [{ status: 401, detail: 'Unauthorized: Invalid API Key' }],
+    });
+    expect(next).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
Se añadió una prueba unitaria que simula un fallo en la conexión con la base de datos para cubrir completamente el flujo de error del endpoint `/health`.  
Esto asegura que se loguee correctamente el error y se devuelva un status 500 como respuesta.  
Con este cambio se alcanza el 100% de cobertura en dicho archivo.